### PR TITLE
Add make_tuple and forward_as_tuple

### DIFF
--- a/include/tuplet/tuple.hpp
+++ b/include/tuplet/tuple.hpp
@@ -344,7 +344,7 @@ namespace tuplet {
 template <typename... Ts>
 constexpr auto make_tuple(Ts&&... args)
 {
-    return tuplet::tuple<std::unwrap_ref_decay_t<Ts>...> { std::forward<Ts>(args)... };
+    return tuplet::tuple<typename std::unwrap_ref_decay<Ts>::type...> { std::forward<Ts>(args)... };
 }
 
 template <typename... T>

--- a/include/tuplet/tuple.hpp
+++ b/include/tuplet/tuple.hpp
@@ -338,6 +338,22 @@ constexpr auto tuple_cat(T1&& t1, T2&&... t2) {
 }
 } // namespace tuplet
 
+// tuplet::make_tuple implementation
+// tuplet::forward_as_tuple implementation
+namespace tuplet {
+template <typename... Ts>
+constexpr auto make_tuple(Ts&&... args)
+{
+    return tuplet::tuple<std::unwrap_ref_decay_t<Ts>...> { std::forward<Ts>(args)... };
+}
+
+template <typename... T>
+constexpr auto forward_as_tuple(T&&... a) noexcept
+{
+    return tuple<T&&...> { std::forward<T>(a)... };
+}
+} // namespace tuplet
+
 // tuplet literals
 namespace tuplet::literals {
 template <char... D>


### PR DESCRIPTION
These two functions are commonly used with `std::tuple`.  We now have
our own versions of them.

`make_tuple` works as described by cppreference.com.  It uses
`std::unwrap_ref_decay` to get the "actual" type.

Note that according to cppreference.com, make_tuple is not `constexpr`.
I see no reason for that, though.

-----

Note: I didn't have the time to write tests, yet. I'm using the exact same implementation in my project right now, though.