### PR TITLE
Implements comparison operator for tuples

### DIFF
--- a/include/tuplet/tuple.hpp
+++ b/include/tuplet/tuple.hpp
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <type_traits>
 #include <utility>
+#include <compare>
 
 // tuplet convenience types
 namespace tuplet {

--- a/include/tuplet/tuple.hpp
+++ b/include/tuplet/tuple.hpp
@@ -76,6 +76,8 @@ struct type_map : Bases... {
     using base_list = type_list<Bases...>;
     using Bases::operator[]...;
     using Bases::decl_elem...;
+    auto operator<=>(type_map const&) const = default;
+    bool operator==(type_map const&) const = default;
 };
 
 template <size_t I, class T>
@@ -91,6 +93,8 @@ struct tuple_elem {
     constexpr decltype(auto) operator[](tag<I>) && {
         return (std::move(*this).value);
     }
+    auto operator<=>(tuple_elem const&) const = default;
+    bool operator==(tuple_elem const&) const = default;
 };
 template <class T>
 using unwrap_ref_decay_t = typename std::unwrap_ref_decay<T>::type;
@@ -168,6 +172,8 @@ struct tuple : tuple_base_t<T...> {
         return *this;
     }
 
+    auto operator<=>(tuple const&) const = default;
+    bool operator==(tuple const&) const = default;
    private:
     template <class U, class... B1, class... B2>
     constexpr void eq_impl(U&& u, type_list<B1...>, type_list<B2...>) {
@@ -194,6 +200,8 @@ struct tuple<> : tuple_base_t<> {
     constexpr auto& operator=(U&& tup) noexcept { return *this; }
 
     constexpr auto& assign() noexcept { return *this; }
+    auto operator<=>(tuple const&) const = default;
+    bool operator==(tuple const&) const = default;
 };
 template <class... Ts>
 tuple(Ts...) -> tuple<unwrap_ref_decay_t<Ts>...>;
@@ -232,6 +240,8 @@ struct pair {
         second = std::forward<S2>(s);
         return *this;
     }
+    auto operator<=>(pair const&) const = default;
+    bool operator==(pair const&) const = default;
 };
 template <class A, class B>
 pair(A, B) -> pair<unwrap_ref_decay_t<A>, unwrap_ref_decay_t<B>>;

--- a/test/compare_1.cpp
+++ b/test/compare_1.cpp
@@ -1,4 +1,5 @@
 #include <cstdio>
+#include <functional>
 #include <tuplet/tuple.hpp>
 
 int main() {
@@ -9,4 +10,26 @@ int main() {
     static_assert(t1 == t1, "Tuple equality broken");
     static_assert(t1 != t2, "Tuple equality broken");
     static_assert(t1 < t2, "Tuple compare broken");
+
+    int a = 10, b = 1, c = 2;
+
+    std::reference_wrapper<int> ra = std::ref(a);
+    static_assert(
+        std::is_same_v<tuplet::unwrap_ref_decay_t<decltype(ra)>, int&>,
+        "unwrap_ref_decay_t broken");
+    static_assert(
+        std::is_same_v<tuplet::unwrap_ref_decay_t<decltype(std::ref(a))>, int&>,
+        "unwrap_ref_decay_t broken");
+    tuple<const int&, int&> t3 = tuple {std::cref(a), std::ref(b)};
+    tuple t4 = {std::cref(a), std::ref(c)};
+    static_assert(std::is_same_v<decltype(t4), tuple<const int&, int&>>);
+
+    if (t3 > t4) {
+        return 1;
+    }
+    b = 2;
+    c = 1;
+    if (t3 < t4) {
+        return 1;
+    }
 }

--- a/test/compare_1.cpp
+++ b/test/compare_1.cpp
@@ -1,0 +1,12 @@
+#include <cstdio>
+#include <tuplet/tuple.hpp>
+
+int main() {
+    using tuplet::tuple;
+
+    constexpr tuple t1 {10, 1};
+    constexpr tuple t2 {10, 2};
+    static_assert(t1 == t1, "Tuple equality broken");
+    static_assert(t1 != t2, "Tuple equality broken");
+    static_assert(t1 < t2, "Tuple compare broken");
+}


### PR DESCRIPTION
This pull request is to merge support for comparison into tuplet. It provides `operator <=>` and `operator ==`, from which the other comparison and equality operators can be defined.

For tuples containing values that implement `==` and `<=>`, these operators are defaulted, at all levels, however for tuples containing references, the `tuple_elem`s corresponding to the references implement them explicitly:
```cpp
    // Implements comparison for tuples containing reference types
    constexpr auto operator<=>(tuple_elem const& other) const
        noexcept(noexcept(value <=> other.value))
        requires(std::is_reference_v<T> && ordered<T>) {
        return value <=> other.value;
    }
    constexpr bool operator==(tuple_elem const& other) const
        noexcept(noexcept(value == other.value))
        requires(std::is_reference_v<T> && equality_comparable<T>) {
        return value == other.value;
    }
```