### PR TITLE
Heterogenous comparisons

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -38,7 +38,7 @@ jobs:
             compiler: clang++-11
             flags: ""
             build_type: Debug
-            install_compiler: sudo apt install g++-10 && sudo apt install clang-10
+            install_compiler: sudo apt install g++-10 && sudo apt install clang-11
 
           - name: ubuntu-latest-clang-12
             os: ubuntu-latest

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -33,6 +33,13 @@ jobs:
             build_type: Debug
             install_compiler: sudo apt install g++-10 && sudo apt install clang-10
 
+          - name: ubuntu-latest-clang-11
+            os: ubuntu-latest
+            compiler: clang++-11
+            flags: ""
+            build_type: Debug
+            install_compiler: sudo apt install g++-10 && sudo apt install clang-10
+
           - name: ubuntu-latest-clang-12
             os: ubuntu-latest
             compiler: clang++-12
@@ -52,6 +59,19 @@ jobs:
               libc++1-10
               libc++abi1-10
               libc++abi-10-dev
+
+          - name: ubuntu-latest-clang-11-libc++
+            os: ubuntu-latest
+            compiler: clang++-11
+            flags: "-stdlib=libc++"
+            build_type: Debug
+            install_compiler: >
+              sudo apt-get install
+              clang++-11
+              libc++-11-dev
+              libc++1-11
+              libc++abi1-11
+              libc++abi-11-dev
 
           - name: ubuntu-latest-clang-12-libc++
             os: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,9 +70,14 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/tuplet
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
-
 include(helper)
-if(PROJECT_IS_TOP_LEVEL)
+
+option(
+    BUILD_TESTING
+    "Build testing for tuplet"
+    ON)
+
+if(PROJECT_IS_TOP_LEVEL AND BUILD_TESTING)
     include(CTest)
 
     set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/test/test_compare.cpp
+++ b/test/test_compare.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
+#include <string>
 #include <tuplet/format.hpp>
 #include <tuplet/tuple.hpp>
 
@@ -15,11 +16,14 @@ TEST_CASE("Lexiconographic ordering", "[compare]") {
     REQUIRE(t1 == t1);
     REQUIRE(t1 < t2);
     REQUIRE(t2 < t3);
+    REQUIRE_FALSE(t1 != t1);
+    REQUIRE_FALSE(t1 > t2);
+    REQUIRE_FALSE(t2 > t3);
 }
 
 TEST_CASE("Empty tuple equals itself", "[compare]") {
-    REQUIRE(tuplet::tuple{} == tuplet::tuple{});
-    REQUIRE_FALSE(tuplet::tuple{} != tuplet::tuple{});
+    REQUIRE(tuplet::tuple {} == tuplet::tuple {});
+    REQUIRE_FALSE(tuplet::tuple {} != tuplet::tuple {});
 }
 
 SCENARIO("We have tuples created with references", "[compare]") {
@@ -44,4 +48,32 @@ SCENARIO("We have tuples created with references", "[compare]") {
             REQUIRE_FALSE(t2 > t1);
         }
     }
+}
+
+SCENARIO("We have tuplet with different but comparable types", "[compare]") {
+    using tuplet::tuple;
+
+    tuple t0 {0, 0};
+    tuple t1 {0, 0.0};
+    tuple t2 {0l, 1};
+    tuple t3 {1.0f, (unsigned short)(0)};
+
+    REQUIRE(t0 == t1);
+    REQUIRE(t1 == t1);
+    REQUIRE(t1 < t2);
+    REQUIRE(t2 < t3);
+    REQUIRE_FALSE(t1 != t1);
+    REQUIRE_FALSE(t1 > t2);
+    REQUIRE_FALSE(t2 > t3);
+}
+
+SCENARIO(
+    "We're comparing tuples containing string_views to ones containing string "
+    "literals",
+    "[compare]") {
+    using tuplet::tuple;
+    tuple t1 {1, 2, std::string("Hello, world!")};
+    tuple t2 {1, 2, "Hello, world!"};
+    STATIC_REQUIRE_FALSE(std::is_same_v<decltype(t1), decltype(t2)>);
+    REQUIRE(t1 == t2);
 }

--- a/test/test_compare.cpp
+++ b/test/test_compare.cpp
@@ -50,6 +50,7 @@ SCENARIO("We have tuples created with references", "[compare]") {
     }
 }
 
+#if !defined(__clang__) || __clang_major__ >= 12
 SCENARIO("We have tuplet with different but comparable types", "[compare]") {
     using tuplet::tuple;
 
@@ -77,3 +78,7 @@ SCENARIO(
     STATIC_REQUIRE_FALSE(std::is_same_v<decltype(t1), decltype(t2)>);
     REQUIRE(t1 == t2);
 }
+#else
+#warning                                                                       \
+    "Heterogenous comparisons between tuples of different types isn't supported in clang 10 or clang 11. Please upgrade to clang 12 for full support for these language features."
+#endif


### PR DESCRIPTION
This merger is to implement comparisons of heterogenous types. For example:

```cpp
#include <string>

using tuplet::tuple;

bool do_stuff() {
    tuple<int, const char*> t1 { 10, "Hello" };
    tuple<int, std::string> t2 { 10, std::string("World") };
    // Comparing t1 and t2 is possible even though they're different types
    return t1 < t2; // Returns true because "Hello" comes before "World"
}
```