### PR TITLE
Fix `-Wunused-parameter` warning

### DIFF
--- a/include/tuplet/tuple.hpp
+++ b/include/tuplet/tuple.hpp
@@ -227,7 +227,7 @@ struct tuple<> : tuple_base_t<> {
 
     template <other_than<tuple> U> // Preserves default assignments
     requires stateless<U>          // Check that U is similarly stateless
-    constexpr auto& operator=(U&& tup) noexcept { return *this; }
+    constexpr auto& operator=(U&&) noexcept { return *this; }
 
     constexpr auto& assign() noexcept { return *this; }
     auto operator<=>(tuple const&) const = default;


### PR DESCRIPTION
As I'm currently just including `tuplet.hpp` in my project and am not
using the full CMake capabilities, yet, all warnings that I've enabled
for my own project are enabled for tuplet as well.

This warning was just a bit annoying.  We can simply remove the argument
name to silence the warning.

Alternative would be:

```cpp
(void) tup;
```

or to wrap that in a custom macro such as `TUPLET_UNUSED(tup)`.