### PR TITLE
Workaround to Clang crashes with nested tuples

### DIFF
--- a/include/tuplet/tuple.hpp
+++ b/include/tuplet/tuple.hpp
@@ -649,11 +649,8 @@ namespace tuplet {
             return *this;
         }
 
-#if defined(__clang__) // Workaround to clang crashes with nested tuples
         template <class... U>
-#else
-        template <TUPLET_WEAK_CONCEPT(assignable_to<T>)... U>
-#endif
+        TUPLET_WEAK_REQUIRES((assignable_to<U, T> && ...))
         constexpr auto& assign(U&&... values) {
             _assign(base_list {}, static_cast<U&&>(values)...);
             return *this;

--- a/include/tuplet/tuple.hpp
+++ b/include/tuplet/tuple.hpp
@@ -649,7 +649,11 @@ namespace tuplet {
             return *this;
         }
 
+#if defined(__clang__) // Workaround to clang crashes with nested tuples
+        template <class... U>
+#else
         template <TUPLET_WEAK_CONCEPT(assignable_to<T>)... U>
+#endif
         constexpr auto& assign(U&&... values) {
             _assign(base_list {}, static_cast<U&&>(values)...);
             return *this;

--- a/test/test_assignment.cpp
+++ b/test/test_assignment.cpp
@@ -91,3 +91,13 @@ TEST_CASE("Assignment to empty tuple", "[assign]") {
     // Checks that self-assignment compiles
     empty_tuple = empty_tuple;
 }
+
+TEST_CASE("Check assignment of tuple with nested tuples", "[assign]") {
+    tuplet::tuple<int, tuplet::tuple<double>, tuplet::tuple<int>> t;
+
+    t.assign(1, tuplet::make_tuple(2.0), tuplet::make_tuple(3));
+
+    REQUIRE(t[0_tag] == 1);
+    REQUIRE(t[1_tag][0_tag] == 2.0);
+    REQUIRE(t[2_tag][0_tag] == 3);
+}


### PR DESCRIPTION
Hi! Following issue #26, I have found a workaround that seems to solve clang problems.

The proposed change, however, turns off the use of concepts in the `tuplet::tuple::assign` function.
From what I have seen, in this case, concepts are used for better error messages and not to choose the correct overload, so everything should work just fine (with worse error messages though).

Here is a [godbolt](https://godbolt.org/z/Y9WE344Tf) testing compilation from clang 10 to 15.