### PR TITLE
Update catch2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,8 +106,8 @@ if(PROJECT_IS_TOP_LEVEL AND BUILD_TESTING)
     find_or_fetch(
         Catch2
         https://github.com/catchorg/catch2.git
-        v3.2.0
-        3.2.0)
+        v3.3.2
+        3.3.2)
     FetchContent_MakeAvailable(${remote_dependencies})
 
     add_executable(


### PR DESCRIPTION
I tried building, but on `cmake --build build/` I got
```
In file included from /home/chriselrod/Documents/progwork/cxx/misc/tuplet/build/_deps/catch2-src/src/catch2/catch_test_spec.cpp:10:
/home/chriselrod/Documents/progwork/cxx/misc/tuplet/build/_deps/catch2-src/src/catch2/../catch2/internal/catch_string_manip.hpp:47:14: error: ‘uint64_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
   47 |         std::uint64_t m_count;
      |              ^~~~~~~~
      |              wint_t
```
After updating Catch2, I got
```
➜ tuplet git:(main) 1M$ cmake --build build/ 
[0/2] Re-checking globbed directories...
[139/139] Linking CXX executable test_tuplet
➜ tuplet git:(main) 1M$ build/bench 
2023-06-27T00:28:27-04:00
Running /home/chriselrod/Documents/progwork/cxx/misc/tuplet/build/bench
Run on (8 X 4700 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 1280 KiB (x4)
  L3 Unified 12288 KiB (x1)
Load Average: 1.68, 0.73, 0.41
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
----------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations
----------------------------------------------------------------------------------
BM_copy/heterogenous_std_tuple_v4             3.22 ns         3.22 ns    219583379
BM_copy/heterogenous_tuplet_tuple_v4          1.63 ns         1.62 ns    432610263
BM_copy/heterogenous_std_tuple_v8             5.81 ns         5.80 ns    119855379
BM_copy/heterogenous_tuplet_tuple_v8          1.63 ns         1.63 ns    429027564
BM_copy/heterogenous_std_tuple_v16            10.8 ns         10.8 ns     64471898
BM_copy/heterogenous_tuplet_tuple_v16         2.55 ns         2.55 ns    274174974
BM_copy/heterogenous_std_tuple_v32            23.0 ns         23.0 ns     30602571
BM_copy/heterogenous_tuplet_tuple_v32         3.16 ns         3.16 ns    221699446
BM_copy/heterogenous_std_tuple_v64            42.4 ns         42.3 ns     16577660
BM_copy/heterogenous_tuplet_tuple_v64         4.47 ns         4.47 ns    156825715
BM_copy/heterogenous_std_tuple_v128           81.6 ns         81.5 ns      8516261
BM_copy/heterogenous_tuplet_tuple_v128        10.4 ns         10.4 ns     67365062
BM_copy/heterogenous_std_tuple_v256            160 ns          159 ns      4394481
BM_copy/heterogenous_tuplet_tuple_v256        17.4 ns         17.4 ns     40284985
BM_copy/heterogenous_std_tuple_v512            441 ns          441 ns      1585020
BM_copy/heterogenous_tuplet_tuple_v512        40.7 ns         40.7 ns     17163847
BM_copy/heterogenous_std_tuple_v1024           880 ns          879 ns       787227
BM_copy/heterogenous_tuplet_tuple_v1024       72.1 ns         72.0 ns      9452734
BM_copy/homogenous_std_tuple_v4               1.78 ns         1.78 ns    388348052
BM_copy/homogenous_tuplet_tuple_v4            1.60 ns         1.60 ns    435859284
BM_copy/homogenous_std_tuple_v8               2.03 ns         2.03 ns    344465768
BM_copy/homogenous_tuplet_tuple_v8            1.59 ns         1.59 ns    440441353
BM_copy/homogenous_std_tuple_v16              2.74 ns         2.74 ns    255365174
BM_copy/homogenous_tuplet_tuple_v16           2.61 ns         2.59 ns    269994587
BM_copy/homogenous_std_tuple_v32              5.19 ns         5.19 ns    137856334
BM_copy/homogenous_tuplet_tuple_v32           3.19 ns         3.19 ns    219191005
BM_copy/homogenous_std_tuple_v64              8.53 ns         8.52 ns     81923445
BM_copy/homogenous_tuplet_tuple_v64           4.53 ns         4.53 ns    154496814
BM_copy/homogenous_std_tuple_v128             17.4 ns         17.4 ns     39363894
BM_copy/homogenous_tuplet_tuple_v128          10.5 ns         10.5 ns     66265337
BM_copy/homogenous_std_tuple_v256             25.9 ns         25.9 ns     27093761
BM_copy/homogenous_tuplet_tuple_v256          17.6 ns         17.6 ns     39605637
BM_copy/homogenous_std_tuple_v512             54.7 ns         54.6 ns     12901193
BM_copy/homogenous_tuplet_tuple_v512          40.7 ns         40.7 ns     17219328
BM_copy/homogenous_std_tuple_v1024             106 ns          106 ns      6604631
BM_copy/homogenous_tuplet_tuple_v1024         74.4 ns         74.4 ns      9177060
BM_copy/single_elem_std_tuple_v4              2.02 ns         2.02 ns    348118617
BM_copy/single_elem_tuplet_tuple_v4           1.69 ns         1.69 ns    432971917
BM_copy/single_elem_std_tuple_v8              2.41 ns         2.41 ns    271565333
BM_copy/single_elem_tuplet_tuple_v8           1.67 ns         1.67 ns    433131718
BM_copy/single_elem_std_tuple_v16             3.39 ns         3.38 ns    204863801
BM_copy/single_elem_tuplet_tuple_v16          2.73 ns         2.73 ns    261981997
BM_copy/single_elem_std_tuple_v32             4.22 ns         4.22 ns    160993024
BM_copy/single_elem_tuplet_tuple_v32          3.32 ns         3.32 ns    210122941
BM_copy/single_elem_std_tuple_v64             6.07 ns         6.06 ns    112152166
BM_copy/single_elem_tuplet_tuple_v64          4.71 ns         4.71 ns    149149259
BM_copy/single_elem_std_tuple_v128            11.0 ns         11.0 ns     59871213
BM_copy/single_elem_tuplet_tuple_v128         10.8 ns         10.8 ns     64056236
BM_copy/single_elem_std_tuple_v256            24.2 ns         24.2 ns     28596236
BM_copy/single_elem_tuplet_tuple_v256         18.1 ns         18.1 ns     38590369
BM_copy/single_elem_std_tuple_v512            55.5 ns         55.5 ns     12147987
BM_copy/single_elem_tuplet_tuple_v512         41.5 ns         41.5 ns     16675004
BM_copy/single_elem_std_tuple_v1024            106 ns          106 ns      6571915
BM_copy/single_elem_tuplet_tuple_v1024        74.2 ns         74.1 ns      9207511
```