### PR TITLE
Added type-indexed get function

### DIFF
--- a/test/test_core.cpp
+++ b/test/test_core.cpp
@@ -8,6 +8,33 @@
 static_assert(CATCH_VERSION_MAJOR >= 3);
 static_assert(CATCH_VERSION_MINOR >= 0);
 
+
+TEST_CASE("Test get type for tuples containing unique types", "[core][get<T>]") {
+    auto t1 = tuplet::tuple<int, double, std::string> {10, .2, "Hello"};
+    auto t2 = tuplet::make_tuple(
+        short(5),
+        long(-129837),
+        std::string("The quick brown fox jumps over the lazy dogs"));
+
+    REQUIRE(tuplet::get<int>(t1) == 10);
+    REQUIRE(tuplet::get<double>(t1) == .2);
+    REQUIRE(tuplet::get<std::string>(t1) == "Hello");
+
+    REQUIRE(tuplet::get<int>(t1) == tuplet::get<0>(t1));
+    REQUIRE(tuplet::get<double>(t1) == tuplet::get<1>(t1));
+    REQUIRE(tuplet::get<std::string>(t1) == tuplet::get<2>(t1));
+
+    REQUIRE(tuplet::get<short>(t2) == 5);
+    REQUIRE(tuplet::get<long>(t2) == -129837);
+    REQUIRE(
+        tuplet::get<std::string>(t2)
+        == std::string("The quick brown fox jumps over the lazy dogs"));
+
+    REQUIRE(tuplet::get<short>(t2) == tuplet::get<0>(t2));
+    REQUIRE(tuplet::get<long>(t2) == tuplet::get<1>(t2));
+    REQUIRE(tuplet::get<std::string>(t2) == tuplet::get<2>(t2));
+}
+
 TEST_CASE("Test handling of tuples containing refs", "[core]") {
     int a = 0;
     int b = 0;

--- a/test/test_core.cpp
+++ b/test/test_core.cpp
@@ -9,12 +9,13 @@ static_assert(CATCH_VERSION_MAJOR >= 3);
 static_assert(CATCH_VERSION_MINOR >= 0);
 
 
-TEST_CASE("Test get type for tuples containing unique types", "[core][get<T>]") {
+TEST_CASE("Test get with types stored once", "[core][get<T>]") {
     auto t1 = tuplet::tuple<int, double, std::string> {10, .2, "Hello"};
     auto t2 = tuplet::make_tuple(
         short(5),
         long(-129837),
-        std::string("The quick brown fox jumps over the lazy dogs"));
+        std::string("The quick brown fox jumps over the lazy dogs"),
+        short(1));
 
     REQUIRE(tuplet::get<int>(t1) == 10);
     REQUIRE(tuplet::get<double>(t1) == .2);
@@ -24,15 +25,15 @@ TEST_CASE("Test get type for tuples containing unique types", "[core][get<T>]") 
     REQUIRE(tuplet::get<double>(t1) == tuplet::get<1>(t1));
     REQUIRE(tuplet::get<std::string>(t1) == tuplet::get<2>(t1));
 
-    REQUIRE(tuplet::get<short>(t2) == 5);
     REQUIRE(tuplet::get<long>(t2) == -129837);
     REQUIRE(
         tuplet::get<std::string>(t2)
         == std::string("The quick brown fox jumps over the lazy dogs"));
 
-    REQUIRE(tuplet::get<short>(t2) == tuplet::get<0>(t2));
+    REQUIRE(tuplet::get<0>(t2) == 5);
     REQUIRE(tuplet::get<long>(t2) == tuplet::get<1>(t2));
     REQUIRE(tuplet::get<std::string>(t2) == tuplet::get<2>(t2));
+    REQUIRE(tuplet::get<3>(t2) == 1);
 }
 
 TEST_CASE("Test handling of tuples containing refs", "[core]") {


### PR DESCRIPTION
Hi!

I hope this functionality was not already present (and that can also be useful to others as well).

I added a type-based overload to the tuplet::get function that works with types as the std::get for std::tuple.

The added overload extracts the element of the tuple whose type matches. As the corresponding std::get,  it fails to compile unless the tuple has exactly one element of that type.

The concept `type_indexable` is used when concepts are available.
There is also a static assert to provide a clearer compile error when the function is invoked with duplicate types.

Cheers

PS:
I noticed that some automatic checks fail when I posted the pull request, but I have no idea how to fix the problem :/
